### PR TITLE
feat: Add automatic settlement of funds

### DIFF
--- a/calculate_settlement.php
+++ b/calculate_settlement.php
@@ -6,6 +6,7 @@ require_once 'functions.php';
 if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['fund_id'])) {
     $fund_id = $_POST['fund_id'];
     $user_id = $_SESSION['id'];
+    $auto_settle = isset($_POST['auto_settle']) && $_POST['auto_settle'] == '1';
 
     $conn->begin_transaction();
 
@@ -19,53 +20,99 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['fund_id'])) {
             throw new Exception("Il fondo non è attivo e non può essere saldato.");
         }
 
-        // --- Calculations ---
-        $cash_balance = get_fund_cash_balance($conn, $fund_id);
-        $debt_balances = get_group_balances($conn, $fund_id);
+        // --- 2. Calculate Final Balances ---
+        $expense_balances = get_group_balances($conn, $fund_id);
+        $net_contributions = get_net_contributions_by_user($conn, $fund_id);
 
-        // --- Surplus Distribution ---
-        if ($cash_balance > 0) {
-            $total_credit = 0;
-            foreach ($debt_balances as $b) {
-                if ($b['balance'] > 0) {
-                    $total_credit += $b['balance'];
+        $final_balances = [];
+        $all_user_ids = array_unique(array_merge(array_column($expense_balances, 'user_id'), array_keys($net_contributions)));
+
+        foreach ($all_user_ids as $uid) {
+            $expense_balance = 0;
+            $username = ''; // Initialize username
+            foreach ($expense_balances as $b) {
+                if ($b['user_id'] == $uid) {
+                    $expense_balance = $b['balance'];
+                    $username = $b['username'];
+                    break;
                 }
             }
+             // If username is not found in expense balances (e.g., user only contributed), get it from DB
+            if (empty($username)) {
+                $user_data = get_user_by_id($conn, $uid);
+                $username = $user_data['username'] ?? 'Utente Sconosciuto';
+            }
 
-            if ($total_credit > 0) {
-                foreach ($debt_balances as &$b) {
-                    if ($b['balance'] > 0) {
-                        $share_of_surplus = ($b['balance'] / $total_credit) * $cash_balance;
-                        $b['balance'] -= $share_of_surplus; // Reduce what they are owed because they get cash
-                    }
-                }
-                unset($b); // Unset reference
+
+            $net_contribution = $net_contributions[$uid] ?? 0;
+
+            $final_balances[] = [
+                'user_id' => $uid,
+                'username' => $username,
+                'balance' => $expense_balance + $net_contribution
+            ];
+        }
+
+        // --- 3. Simplify Debts to get Peer-to-Peer Payments ---
+        $p2p_payments = simplify_debts($final_balances);
+
+        // --- 4. Calculate Final Balances After P2P Payments ---
+        $balances_after_p2p = [];
+        foreach($final_balances as $b) {
+            $balances_after_p2p[$b['user_id']] = $b['balance'];
+        }
+
+        foreach ($p2p_payments as $p) {
+            $balances_after_p2p[$p['from']] -= $p['amount'];
+            $balances_after_p2p[$p['to']] += $p['amount'];
+        }
+
+        // --- 5. Identify Cash Withdrawals ---
+        $cash_withdrawals = [];
+        foreach ($balances_after_p2p as $uid => $balance) {
+            if ($balance > 0.01) { // Use a small epsilon for float comparison
+                $cash_withdrawals[] = [
+                    'from' => $uid, // Convention: from == to for withdrawal
+                    'to' => $uid,
+                    'amount' => round($balance, 2)
+                ];
             }
         }
 
-        // --- Simplify Debts ---
-        $settlement_payments = simplify_debts($debt_balances);
+        // --- 6. Store All Settlement Payments (P2P and Withdrawals) ---
+        $sql_insert_payment = "INSERT INTO settlement_payments (fund_id, from_user_id, to_user_id, amount) VALUES (?, ?, ?, ?)";
+        $stmt_insert = $conn->prepare($sql_insert_payment);
 
-        // --- Store Settlement Payments ---
-        if (!empty($settlement_payments)) {
-            $sql_insert_payment = "INSERT INTO settlement_payments (fund_id, from_user_id, to_user_id, amount) VALUES (?, ?, ?, ?)";
-            $stmt_insert = $conn->prepare($sql_insert_payment);
-            foreach ($settlement_payments as $payment) {
-                $stmt_insert->bind_param("iiid", $fund_id, $payment['from'], $payment['to'], $payment['amount']);
-                $stmt_insert->execute();
-            }
-            $stmt_insert->close();
+        if ($stmt_insert === false) {
+            throw new Exception("Impossibile preparare la query per l'inserimento dei pagamenti.");
         }
 
-        // --- Update Fund Status ---
-        $sql_update_status = "UPDATE shared_funds SET status = 'settling' WHERE id = ?";
+        // Store P2P payments
+        foreach ($p2p_payments as $payment) {
+            $stmt_insert->bind_param("iiid", $fund_id, $payment['from'], $payment['to'], $payment['amount']);
+            $stmt_insert->execute();
+        }
+
+        // Store cash withdrawals
+        foreach ($cash_withdrawals as $withdrawal) {
+            $stmt_insert->bind_param("iiid", $fund_id, $withdrawal['from'], $withdrawal['to'], $withdrawal['amount']);
+            $stmt_insert->execute();
+        }
+        $stmt_insert->close();
+
+        // --- 7. Update Fund Status ---
+        $new_status = $auto_settle ? 'settling_auto' : 'settling';
+        $sql_update_status = "UPDATE shared_funds SET status = ? WHERE id = ?";
         $stmt_update = $conn->prepare($sql_update_status);
-        $stmt_update->bind_param("i", $fund_id);
+        if ($stmt_update === false) {
+            throw new Exception("Impossibile preparare la query per l'aggiornamento dello stato del fondo.");
+        }
+        $stmt_update->bind_param("si", $new_status, $fund_id);
         $stmt_update->execute();
         $stmt_update->close();
 
         $conn->commit();
-        header("location: fund_details.php?id=" . $fund_id . "&message=Il processo di chiusura del fondo è iniziato. Ora i membri devono confermare i pagamenti.&type=success");
+        header("location: fund_details.php?id=" . $fund_id . "&message=Il processo di chiusura del fondo è iniziato.&type=success");
 
     } catch (Exception $e) {
         $conn->rollback();

--- a/fund_details.php
+++ b/fund_details.php
@@ -166,6 +166,72 @@ if ($fund['status'] === 'settling') {
                         <?php endforeach; endif; ?>
                     </div>
                 </div>
+            <?php elseif ($fund['status'] === 'settling_auto'):
+                $p2p_payments = array_filter($settlement_payments, function($p) {
+                    return $p['from_user_id'] != $p['to_user_id'];
+                });
+            ?>
+                <div class="bg-gray-800 rounded-2xl p-6">
+                    <h2 class="text-xl font-bold text-white mb-2">Saldaconto Automatico</h2>
+                    <p class="text-gray-400 mb-6">Seleziona i conti per registrare automaticamente le transazioni di debito/credito.</p>
+
+                    <form action="process_automatic_settlement.php" method="POST">
+                        <input type="hidden" name="fund_id" value="<?php echo $fund_id; ?>">
+                        <div class="space-y-4">
+                            <?php if(empty($p2p_payments)): ?>
+                                <p class="text-center text-gray-500 py-4">Nessun debito da saldare tra i membri.</p>
+                            <?php else:
+                                // Create a map of user_id to their accounts
+                                $user_accounts_map = [];
+                                foreach ($members as $member) {
+                                    $user_accounts_map[$member['id']] = get_user_accounts($conn, $member['id']);
+                                }
+                            ?>
+                                <?php foreach($p2p_payments as $payment): ?>
+                                    <div class="bg-gray-700/50 p-4 rounded-lg">
+                                        <p class="text-white text-center mb-3">
+                                            <span class="font-bold"><?php echo htmlspecialchars($payment['from_username']); ?></span> deve pagare
+                                            <span class="font-bold text-primary-400">€<?php echo number_format($payment['amount'], 2, ',', '.'); ?></span> a
+                                            <span class="font-bold"><?php echo htmlspecialchars($payment['to_username']); ?></span>
+                                        </p>
+                                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                            <!-- From Account Selection -->
+                                            <div>
+                                                <label class="block text-sm font-medium text-gray-300 mb-1">Conto di <?php echo htmlspecialchars($payment['from_username']); ?> (Uscita)</label>
+                                                <?php if ($user_id == $payment['from_user_id']): ?>
+                                                    <select name="payments[<?php echo $payment['id']; ?>][from_account]" required class="w-full bg-gray-900 text-white rounded-lg px-3 py-2">
+                                                        <?php foreach($user_accounts_map[$payment['from_user_id']] as $account): ?>
+                                                            <option value="<?php echo $account['id']; ?>"><?php echo htmlspecialchars($account['name']); ?></option>
+                                                        <?php endforeach; ?>
+                                                    </select>
+                                                <?php else: ?>
+                                                    <p class="text-gray-400 text-sm italic mt-2">In attesa che <?php echo htmlspecialchars($payment['from_username']); ?> scelga il conto.</p>
+                                                <?php endif; ?>
+                                            </div>
+                                            <!-- To Account Selection -->
+                                            <div>
+                                                <label class="block text-sm font-medium text-gray-300 mb-1">Conto di <?php echo htmlspecialchars($payment['to_username']); ?> (Entrata)</label>
+                                                <?php if ($user_id == $payment['to_user_id']): ?>
+                                                    <select name="payments[<?php echo $payment['id']; ?>][to_account]" required class="w-full bg-gray-900 text-white rounded-lg px-3 py-2">
+                                                        <?php foreach($user_accounts_map[$payment['to_user_id']] as $account): ?>
+                                                            <option value="<?php echo $account['id']; ?>"><?php echo htmlspecialchars($account['name']); ?></option>
+                                                        <?php endforeach; ?>
+                                                    </select>
+                                                <?php else: ?>
+                                                    <p class="text-gray-400 text-sm italic mt-2">In attesa che <?php echo htmlspecialchars($payment['to_username']); ?> scelga il conto.</p>
+                                                <?php endif; ?>
+                                            </div>
+                                        </div>
+                                    </div>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
+                        </div>
+
+                        <div class="mt-6 text-right">
+                             <button type="submit" class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-5 rounded-lg">Conferma e Crea Transazioni</button>
+                        </div>
+                    </form>
+                </div>
             <?php else: // active or archived ?>
                 <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
                     <!-- Colonna Principale -->
@@ -435,13 +501,19 @@ if ($fund['status'] === 'settling') {
              <div class="bg-gray-800 rounded-lg p-6 z-10 max-w-md text-center shadow-lg">
                 <h2 class="text-xl font-bold mb-4 text-white">Chiudere il Conto?</h2>
                 <p class="text-gray-400">Questa azione calcolerà i pagamenti finali e metterà il fondo in modalità "chiusura". Non potrai più aggiungere nuove spese o contributi. Sei sicuro?</p>
-                <div class="mt-6 flex justify-center gap-4">
-                    <button type="button" onclick="closeModal('settle-up-modal')" class="bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-5 rounded-lg">Annulla</button>
-                    <form action="calculate_settlement.php" method="POST">
+                <form action="calculate_settlement.php" method="POST">
+                    <div class="mt-4 text-left">
+                        <label class="flex items-center text-gray-300">
+                            <input type="checkbox" name="auto_settle" value="1" class="h-4 w-4 rounded border-gray-600 bg-gray-700 text-primary-600 focus:ring-primary-500">
+                            <span class="ml-2">Salda automaticamente i debiti creando le transazioni</span>
+                        </label>
+                    </div>
+                    <div class="mt-6 flex justify-center gap-4">
+                        <button type="button" onclick="closeModal('settle-up-modal')" class="bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-5 rounded-lg">Annulla</button>
                         <input type="hidden" name="fund_id" value="<?php echo $fund_id; ?>">
                         <button type="submit" class="bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-5 rounded-lg">Sì, chiudi conto</button>
-                    </form>
-                </div>
+                    </div>
+                </form>
              </div>
         </div>
     <?php endif; ?>

--- a/process_automatic_settlement.php
+++ b/process_automatic_settlement.php
@@ -1,0 +1,114 @@
+<?php
+session_start();
+require_once 'db_connect.php';
+require_once 'functions.php';
+
+if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['fund_id'])) {
+    $fund_id = $_POST['fund_id'];
+    $user_id = $_SESSION['id'];
+    $payments_data = $_POST['payments'] ?? [];
+
+    $conn->begin_transaction();
+
+    try {
+        // --- 1. Security and Fund Status Check ---
+        $fund = get_shared_fund_details($conn, $fund_id, $user_id);
+        if (!$fund) {
+            throw new Exception("Fondo non trovato o accesso non autorizzato.");
+        }
+        if ($fund['status'] !== 'settling_auto') {
+            throw new Exception("Questo fondo non è in modalità di saldaconto automatico.");
+        }
+
+        // --- 2. Get or Create a Category for Settlement Transactions ---
+        $category_name = "Regolamento Fondo";
+        $category = get_category_by_name($conn, $category_name, $user_id);
+        if (!$category) {
+            $sql_create_cat = "INSERT INTO categories (user_id, name, type, icon) VALUES (?, ?, 'expense', '⚖️')";
+            $stmt_create_cat = $conn->prepare($sql_create_cat);
+            $stmt_create_cat->bind_param("is", $user_id, $category_name);
+            $stmt_create_cat->execute();
+            $category_id = $stmt_create_cat->insert_id;
+            $stmt_create_cat->close();
+        } else {
+            $category_id = $category['id'];
+        }
+
+        $income_category = get_category_by_name($conn, $category_name, $user_id);
+        if (!$income_category) {
+            $sql_create_cat = "INSERT INTO categories (user_id, name, type, icon) VALUES (?, ?, 'income', '⚖️')";
+            $stmt_create_cat = $conn->prepare($sql_create_cat);
+            $stmt_create_cat->bind_param("is", $user_id, $category_name);
+            $stmt_create_cat->execute();
+            $income_category_id = $stmt_create_cat->insert_id;
+            $stmt_create_cat->close();
+        } else {
+            $income_category_id = $income_category['id'];
+        }
+
+
+        // --- 3. Process each payment ---
+        $settlement_payments = get_settlement_payments($conn, $fund_id);
+
+        $sql_insert_tx = "INSERT INTO transactions (user_id, account_id, category_id, amount, type, description, transaction_date) VALUES (?, ?, ?, ?, ?, ?, ?)";
+        $stmt_insert_tx = $conn->prepare($sql_insert_tx);
+
+        $today = date('Y-m-d');
+
+        foreach ($settlement_payments as $payment) {
+            if ($payment['from_user_id'] == $payment['to_user_id']) continue; // Skip withdrawals
+
+            $payment_id = $payment['id'];
+            if (!isset($payments_data[$payment_id])) {
+                // This could happen if a user hasn't selected their account yet.
+                // For simplicity, we'll throw an error. A more complex implementation could save partial progress.
+                throw new Exception("Dati mancanti per il pagamento ID " . $payment_id . ". Assicurati che tutti abbiano selezionato il proprio conto.");
+            }
+
+            $from_user_id = $payment['from_user_id'];
+            $to_user_id = $payment['to_user_id'];
+            $amount = $payment['amount'];
+            $from_account_id = $payments_data[$payment_id]['from_account'];
+            $to_account_id = $payments_data[$payment_id]['to_account'];
+
+            // Create Expense Transaction for Payer
+            $expense_amount = -$amount;
+            $expense_desc = "Pagamento a " . $payment['to_username'] . " per fondo '" . $fund['name'] . "'";
+            $stmt_insert_tx->bind_param("iiidsss", $from_user_id, $from_account_id, $category_id, $expense_amount, 'expense', $expense_desc, $today);
+            $stmt_insert_tx->execute();
+
+            // Create Income Transaction for Payee
+            $income_desc = "Pagamento da " . $payment['from_username'] . " per fondo '" . $fund['name'] . "'";
+            $stmt_insert_tx->bind_param("iiidsss", $to_user_id, $to_account_id, $income_category_id, $amount, 'income', $income_desc, $today);
+            $stmt_insert_tx->execute();
+        }
+        $stmt_insert_tx->close();
+
+        // --- 4. Archive the fund ---
+        $sql_archive = "UPDATE shared_funds SET status = 'archived' WHERE id = ?";
+        $stmt_archive = $conn->prepare($sql_archive);
+        $stmt_archive->bind_param("i", $fund_id);
+        $stmt_archive->execute();
+        $stmt_archive->close();
+
+        // --- 5. (Optional) Delete settlement payment records now that they are processed ---
+        // $sql_delete = "DELETE FROM settlement_payments WHERE fund_id = ?";
+        // $stmt_delete = $conn->prepare($sql_delete);
+        // $stmt_delete->bind_param("i", $fund_id);
+        // $stmt_delete->execute();
+        // $stmt_delete->close();
+
+        $conn->commit();
+        header("location: fund_details.php?id=" . $fund_id . "&message=Saldaconto completato e transazioni create con successo!&type=success");
+
+    } catch (Exception $e) {
+        $conn->rollback();
+        header("location: fund_details.php?id=" . $fund_id . "&message=Errore: " . $e->getMessage() . "&type=error");
+    } finally {
+        $conn->close();
+    }
+} else {
+    header("location: shared_funds.php");
+    exit;
+}
+?>


### PR DESCRIPTION
This commit introduces a new feature that allows the fund creator to automatically settle debts by creating the corresponding transactions in the users' personal accounts.

When closing a fund, the creator is now presented with an option to "Settle debts automatically". If selected, the fund enters a new `settling_auto` state.

In this state, a new UI is presented to the members of the fund, where they can each select which of their personal accounts should be used for the payments they need to make or receive.

Once all parties have selected their accounts, a new script `process_automatic_settlement.php` is called. This script:
1.  Creates an expense transaction for the payer, debiting their selected account.
2.  Creates an income transaction for the payee, crediting their selected account.
3.  Assigns these transactions to a new dedicated category "Regolamento Fondo" for clarity.
4.  Archives the fund upon successful creation of all transactions.

This feature provides a convenient way for users to settle their debts without leaving the application, while still keeping a clear record of the transactions in their personal ledgers.